### PR TITLE
Add user roles based on a default wordpress install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ public/media/
 
 public/robots.txt
 public/sitemap*.xml
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ci": "payload migrate && pnpm build"
   },
   "dependencies": {
+    "@payloadcms/db-vercel-postgres": "3.9.0",
     "@payloadcms/live-preview-react": "3.9.0",
     "@payloadcms/next": "3.9.0",
     "@payloadcms/payload-cloud": "3.9.0",
@@ -29,6 +30,7 @@
     "@payloadcms/plugin-search": "3.9.0",
     "@payloadcms/plugin-seo": "3.9.0",
     "@payloadcms/richtext-lexical": "3.9.0",
+    "@payloadcms/storage-vercel-blob": "3.9.0",
     "@payloadcms/ui": "3.9.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-label": "^2.0.2",
@@ -36,7 +38,6 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "cross-env": "^7.0.3",
     "geist": "^1.3.0",
     "graphql": "^16.8.2",
     "lucide-react": "^0.378.0",
@@ -50,9 +51,7 @@
     "react-hook-form": "7.45.4",
     "sharp": "0.32.6",
     "tailwind-merge": "^2.3.0",
-    "tailwindcss-animate": "^1.0.7",
-    "@payloadcms/db-vercel-postgres": "3.9.0",
-    "@payloadcms/storage-vercel-blob": "3.9.0"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -63,6 +62,7 @@
     "@types/react-dom": "19.0.1",
     "autoprefixer": "^10.4.19",
     "copyfiles": "^2.4.1",
+    "cross-env": "^7.0.3",
     "eslint": "^9.16.0",
     "eslint-config-next": "15.1.0",
     "postcss": "^8.4.38",

--- a/src/Footer/config.ts
+++ b/src/Footer/config.ts
@@ -3,10 +3,22 @@ import type { GlobalConfig } from 'payload'
 import { link } from '@/fields/link'
 import { revalidateFooter } from './hooks/revalidateFooter'
 
+// Define access control function
+const canAccessFooter = ({ req: { user } }) => {
+  if (!user) return false
+  return ['administrator', 'editor'].includes(user.role || '')
+}
+
 export const Footer: GlobalConfig = {
   slug: 'footer',
   access: {
-    read: () => true,
+    read: () => true, // Anyone can read the footer
+    update: canAccessFooter, // Only admins and editors can update
+  },
+  admin: {
+    description: 'Footer navigation configuration',
+    group: 'Content',
+    hidden: ({ user }) => user?.role === 'subscriber',
   },
   fields: [
     {

--- a/src/Header/config.ts
+++ b/src/Header/config.ts
@@ -3,10 +3,22 @@ import type { GlobalConfig } from 'payload'
 import { link } from '@/fields/link'
 import { revalidateHeader } from './hooks/revalidateHeader'
 
+// Define access control function
+const canAccessHeader = ({ req: { user } }) => {
+  if (!user) return false
+  return ['administrator', 'editor'].includes(user.role || '')
+}
+
 export const Header: GlobalConfig = {
   slug: 'header',
   access: {
-    read: () => true,
+    read: () => true, // Anyone can read the header
+    update: canAccessHeader, // Only admins and editors can update
+  },
+  admin: {
+    description: 'Header navigation configuration',
+    group: 'Content',
+    hidden: ({ user }) => user?.role === 'subscriber',
   },
   fields: [
     {

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -24,45 +24,28 @@ import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/component
 import { default as default_8a7ab0eb7ab5c511aba12e68480bfe5e } from '@/components/BeforeLogin'
 
 export const importMap = {
-  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell':
-    RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField':
-    RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient':
-    InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient':
-    FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#HeadingFeatureClient':
-    HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#ParagraphFeatureClient':
-    ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#UnderlineFeatureClient':
-    UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#BoldFeatureClient':
-    BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#ItalicFeatureClient':
-    ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#LinkFeatureClient':
-    LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/plugin-seo/client#OverviewComponent':
-    OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#MetaTitleComponent':
-    MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#MetaImageComponent':
-    MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#MetaDescriptionComponent':
-    MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#PreviewComponent':
-    PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@/fields/slug/SlugComponent#SlugComponent': SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
-  '@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient':
-    HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#BlocksFeatureClient':
-    BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/plugin-search/client#LinkToDoc': LinkToDoc_aead06e4cbf6b2620c5c51c9ab283634,
-  '@payloadcms/plugin-search/client#ReindexButton': ReindexButton_aead06e4cbf6b2620c5c51c9ab283634,
-  '@/Header/RowLabel#RowLabel': RowLabel_ec255a65fa6fa8d1faeb09cf35284224,
-  '@/Footer/RowLabel#RowLabel': RowLabel_1f6ff6ff633e3695d348f4f3c58f1466,
-  '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
-  '@/components/BeforeLogin#default': default_8a7ab0eb7ab5c511aba12e68480bfe5e,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaTitleComponent": MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
+  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/plugin-search/client#LinkToDoc": LinkToDoc_aead06e4cbf6b2620c5c51c9ab283634,
+  "@payloadcms/plugin-search/client#ReindexButton": ReindexButton_aead06e4cbf6b2620c5c51c9ab283634,
+  "@/Header/RowLabel#RowLabel": RowLabel_ec255a65fa6fa8d1faeb09cf35284224,
+  "@/Footer/RowLabel#RowLabel": RowLabel_1f6ff6ff633e3695d348f4f3c58f1466,
+  "@/components/BeforeDashboard#default": default_1a7510af427896d367a49dbf838d2de6,
+  "@/components/BeforeLogin#default": default_8a7ab0eb7ab5c511aba12e68480bfe5e
 }

--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -1,29 +1,28 @@
-import type { CollectionConfig, PayloadRequest } from 'payload'
+import type { CollectionConfig } from 'payload'
 import { anyone } from '../access/anyone'
 
-type Role = 'administrator' | 'editor' | 'author' | 'contributor' | 'subscriber'
-
-// Define role-based access control
-const canManageCategories = ({ req: { user } }: { req: PayloadRequest }): boolean => {
-  if (!user) return false
-  return ['administrator', 'editor'].includes((user.role as Role) || '')
+// Import access control functions
+const isEditor = ({ req: { user } }) => {
+  return ['administrator', 'editor'].includes(user?.role || '')
 }
 
 export const Categories: CollectionConfig = {
   slug: 'categories',
   access: {
-    // Only administrators and editors can create categories
-    create: canManageCategories,
-    // Only administrators and editors can delete categories
-    delete: canManageCategories,
+    // Only editors and administrators can create categories
+    create: isEditor,
+    // Only editors and administrators can delete categories
+    delete: isEditor,
     // Anyone can read categories
     read: anyone,
-    // Only administrators and editors can update categories
-    update: canManageCategories,
+    // Only editors and administrators can update categories
+    update: isEditor,
   },
   admin: {
     useAsTitle: 'title',
-    description: 'Categories can only be managed by administrators and editors.',
+    description: 'Categories can be managed by editors and administrators',
+    group: 'Content',
+    hidden: ({ user }) => user?.role === 'subscriber',
   },
   fields: [
     {

--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -1,24 +1,42 @@
-import type { CollectionConfig } from 'payload'
-
+import type { CollectionConfig, PayloadRequest } from 'payload'
 import { anyone } from '../access/anyone'
-import { authenticated } from '../access/authenticated'
+
+type Role = 'administrator' | 'editor' | 'author' | 'contributor' | 'subscriber'
+
+// Define role-based access control
+const canManageCategories = ({ req: { user } }: { req: PayloadRequest }): boolean => {
+  if (!user) return false
+  return ['administrator', 'editor'].includes((user.role as Role) || '')
+}
 
 export const Categories: CollectionConfig = {
   slug: 'categories',
   access: {
-    create: authenticated,
-    delete: authenticated,
+    // Only administrators and editors can create categories
+    create: canManageCategories,
+    // Only administrators and editors can delete categories
+    delete: canManageCategories,
+    // Anyone can read categories
     read: anyone,
-    update: authenticated,
+    // Only administrators and editors can update categories
+    update: canManageCategories,
   },
   admin: {
     useAsTitle: 'title',
+    description: 'Categories can only be managed by administrators and editors.',
   },
   fields: [
     {
       name: 'title',
       type: 'text',
       required: true,
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      admin: {
+        description: 'Optional description for the category',
+      },
     },
   ],
 }

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -1,25 +1,100 @@
 import type { CollectionConfig } from 'payload'
 
-import { authenticated } from '../../access/authenticated'
+type Role = 'administrator' | 'editor' | 'author' | 'contributor' | 'subscriber'
+
+// Define access control functions based on user roles
+const isAdministrator = ({ req: { user } }) => {
+  return user?.role === 'administrator'
+}
 
 export const Users: CollectionConfig = {
   slug: 'users',
+  auth: {
+    tokenExpiration: 7200, // 2 hours
+    verify: false,
+    maxLoginAttempts: 5,
+    lockTime: 600 * 1000, // lock time in ms (10 minutes)
+    useAPIKey: false,
+    depth: 0,
+    cookies: {
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'Lax',
+      domain: process.env.COOKIE_DOMAIN,
+    },
+  },
   access: {
-    admin: authenticated,
-    create: authenticated,
-    delete: authenticated,
-    read: authenticated,
-    update: authenticated,
+    // Only administrators can access admin UI
+    admin: isAdministrator,
+    // Only administrators can create new users
+    create: isAdministrator,
+    // Only administrators can delete users
+    delete: isAdministrator,
+    // Users can read their own profile, admins can read all
+    read: ({ req: { user } }) => {
+      if (!user) return false
+      if (user.role === 'administrator') return true
+      return {
+        id: {
+          equals: user.id,
+        },
+      }
+    },
+    // Users can update their own profile, admins can update all
+    update: ({ req: { user } }) => {
+      if (!user) return false
+      if (user.role === 'administrator') return true
+      return {
+        id: {
+          equals: user.id,
+        },
+      }
+    },
   },
   admin: {
-    defaultColumns: ['name', 'email'],
+    defaultColumns: ['name', 'email', 'role'],
     useAsTitle: 'name',
+    description: 'Users with role-based permissions',
   },
-  auth: true,
   fields: [
     {
       name: 'name',
       type: 'text',
+      required: true,
+    },
+    {
+      name: 'role',
+      type: 'select',
+      defaultValue: 'subscriber',
+      options: [
+        {
+          label: 'Administrator',
+          value: 'administrator',
+        },
+        {
+          label: 'Editor',
+          value: 'editor',
+        },
+        {
+          label: 'Author',
+          value: 'author',
+        },
+        {
+          label: 'Contributor',
+          value: 'contributor',
+        },
+        {
+          label: 'Subscriber',
+          value: 'subscriber',
+        },
+      ],
+      access: {
+        // Only administrators can change roles
+        update: isAdministrator,
+      },
+      admin: {
+        position: 'sidebar',
+        description: 'The role determines what actions the user can perform',
+      },
     },
   ],
   timestamps: true,

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-type Role = 'administrator' | 'editor' | 'author' | 'contributor' | 'subscriber'
+type Role = 'administrator' | 'editor' | 'author' | 'subscriber'
 
 // Define access control functions based on user roles
 const isAdministrator = ({ req: { user } }) => {
@@ -23,8 +23,10 @@ export const Users: CollectionConfig = {
     },
   },
   access: {
-    // Only administrators can access admin UI
-    admin: isAdministrator,
+    // Allow all authenticated users to access admin UI
+    admin: ({ req: { user } }) => {
+      return Boolean(user)
+    },
     // Only administrators can create new users
     create: isAdministrator,
     // Only administrators can delete users
@@ -53,13 +55,19 @@ export const Users: CollectionConfig = {
   admin: {
     defaultColumns: ['name', 'email', 'role'],
     useAsTitle: 'name',
-    description: 'Users with role-based permissions',
+    description: 'Users with WordPress-like role-based permissions',
+    group: 'Admin',
+    // Hide the Users collection from subscribers in the sidebar
+    hidden: ({ user }) => user?.role === 'subscriber',
   },
   fields: [
     {
       name: 'name',
       type: 'text',
       required: true,
+      admin: {
+        description: 'Your display name',
+      },
     },
     {
       name: 'role',
@@ -79,10 +87,6 @@ export const Users: CollectionConfig = {
           value: 'author',
         },
         {
-          label: 'Contributor',
-          value: 'contributor',
-        },
-        {
           label: 'Subscriber',
           value: 'subscriber',
         },
@@ -90,10 +94,21 @@ export const Users: CollectionConfig = {
       access: {
         // Only administrators can change roles
         update: isAdministrator,
+        // Only show role field to administrators
+        read: isAdministrator,
       },
       admin: {
         position: 'sidebar',
         description: 'The role determines what actions the user can perform',
+      },
+    },
+    {
+      name: 'email',
+      type: 'email',
+      required: true,
+      unique: true,
+      admin: {
+        description: 'Your email address (used for login)',
       },
     },
   ],

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -280,6 +280,7 @@ export interface Media {
 export interface Category {
   id: number;
   title: string;
+  description?: string | null;
   parent?: (number | null) | Category;
   breadcrumbs?:
     | {
@@ -298,7 +299,8 @@ export interface Category {
  */
 export interface User {
   id: number;
-  name?: string | null;
+  name: string;
+  role?: ('administrator' | 'editor' | 'author' | 'contributor' | 'subscriber') | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -1054,6 +1056,7 @@ export interface MediaSelect<T extends boolean = true> {
  */
 export interface CategoriesSelect<T extends boolean = true> {
   title?: T;
+  description?: T;
   parent?: T;
   breadcrumbs?:
     | T
@@ -1072,6 +1075,7 @@ export interface CategoriesSelect<T extends boolean = true> {
  */
 export interface UsersSelect<T extends boolean = true> {
   name?: T;
+  role?: T;
   updatedAt?: T;
   createdAt?: T;
   email?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -160,15 +160,15 @@ export interface Post {
     };
     [k: string]: unknown;
   };
-  relatedPosts?: (number | Post)[] | null;
   categories?: (number | Category)[] | null;
+  authors: (number | User)[];
+  relatedPosts?: (number | Post)[] | null;
   meta?: {
     title?: string | null;
     image?: (number | null) | Media;
     description?: string | null;
   };
   publishedAt?: string | null;
-  authors?: (number | User)[] | null;
   populatedAuthors?:
     | {
         id?: string | null;
@@ -300,7 +300,7 @@ export interface Category {
 export interface User {
   id: number;
   name: string;
-  role?: ('administrator' | 'editor' | 'author' | 'contributor' | 'subscriber') | null;
+  role?: ('administrator' | 'editor' | 'author' | 'subscriber') | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -934,8 +934,9 @@ export interface PostsSelect<T extends boolean = true> {
   title?: T;
   heroImage?: T;
   content?: T;
-  relatedPosts?: T;
   categories?: T;
+  authors?: T;
+  relatedPosts?: T;
   meta?:
     | T
     | {
@@ -944,7 +945,6 @@ export interface PostsSelect<T extends boolean = true> {
         description?: T;
       };
   publishedAt?: T;
-  authors?: T;
   populatedAuthors?:
     | T
     | {


### PR DESCRIPTION
## Implements WordPress-like user roles with

**Role hierarchy:**

- Administrator (full access)
- Editor (manage content)
- Author (create/edit own content)
- Subscriber (view own profile)

**Access controls:**

- Proper collection visibility for each role
- Role-based CRUD permissions
- Profile access restrictions
- Admin UI visibility controls

**Security:**

- Role changes restricted to administrators
- Proper authentication checks
- Cookie security settings